### PR TITLE
Fix "warning: bar is deprecated; use `colors.footer_bar` instead"

### DIFF
--- a/catppuccin.yml
+++ b/catppuccin.yml
@@ -28,7 +28,7 @@ color_schemes:
       focused_match:
         foreground: '#EFF1F5' # base
         background: '#40A02B' # green
-      bar:
+      footer_bar:
         foreground: '#EFF1F5' # base
         background: '#6C6F85' # subtext0
 
@@ -111,7 +111,7 @@ color_schemes:
       focused_match:
         foreground: '#303446' # base
         background: '#A6D189' # green
-      bar:
+      footer_bar:
         foreground: '#303446' # base
         background: '#A5ADCE' # subtext0
 
@@ -194,7 +194,7 @@ color_schemes:
       focused_match:
         foreground: '#24273A' # base
         background: '#A6DA95' # green
-      bar:
+      footer_bar:
         foreground: '#24273A' # base
         background: '#A5ADCB' # subtext0
 
@@ -277,7 +277,7 @@ color_schemes:
       focused_match:
         foreground: '#1E1E2E' # base
         background: '#A6E3A1' # green
-      bar:
+      footer_bar:
         foreground: '#1E1E2E' # base
         background: '#A6ADC8' # subtext0
 


### PR DESCRIPTION
When using the content of catppuccin.yml file as is on this repo, I got this warning message from Alacritty (Version 0.11.0-dev, 40bbdce6):

`[alacritty_config_derive] Config warning: bar is deprecated; use `colors.footer_bar` instead`

This PR removes that warning by updating all the ocurrences of "bar" property name to "footer_bar".