### PR TITLE
feat: update config to use the `schemes` key

### DIFF
--- a/catppuccin.yml
+++ b/catppuccin.yml
@@ -1,4 +1,4 @@
-color_schemes:
+schemes:
 
 
 


### PR DESCRIPTION
Newest Alacritty complains on `color_schemes` field, while work perfectly with just `schemes`