### PR TITLE
fix: use `overlay1` for `dim_foreground`

### DIFF
--- a/catppuccin-frappe.toml
+++ b/catppuccin-frappe.toml
@@ -1,7 +1,7 @@
 [colors.primary]
 background = "#303446"
 foreground = "#C6D0F5"
-dim_foreground = "#C6D0F5"
+dim_foreground = "#838BA7"
 bright_foreground = "#C6D0F5"
 
 [colors.cursor]

--- a/catppuccin-latte.toml
+++ b/catppuccin-latte.toml
@@ -1,7 +1,7 @@
 [colors.primary]
 background = "#EFF1F5"
 foreground = "#4C4F69"
-dim_foreground = "#4C4F69"
+dim_foreground = "#8C8FA1"
 bright_foreground = "#4C4F69"
 
 [colors.cursor]

--- a/catppuccin-macchiato.toml
+++ b/catppuccin-macchiato.toml
@@ -1,7 +1,7 @@
 [colors.primary]
 background = "#24273A"
 foreground = "#CAD3F5"
-dim_foreground = "#CAD3F5"
+dim_foreground = "#8087A2"
 bright_foreground = "#CAD3F5"
 
 [colors.cursor]

--- a/catppuccin-mocha.toml
+++ b/catppuccin-mocha.toml
@@ -1,7 +1,7 @@
 [colors.primary]
 background = "#1E1E2E"
 foreground = "#CDD6F4"
-dim_foreground = "#CDD6F4"
+dim_foreground = "#7f849C"
 bright_foreground = "#CDD6F4"
 
 [colors.cursor]


### PR DESCRIPTION
It now uses "overlay1", which is what [the style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md) says to use for "subtle" text.