### PR TITLE
docs(README): `import` --> `general.import`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 2. Import the desired flavour config in your `alacritty.toml`:
 
     ```toml
-    import = [
+    general.import = [
       # uncomment the flavour you want below:
       "~/.config/alacritty/catppuccin-latte.toml"
       # "~/.config/alacritty/catppuccin-frappe.toml"


### PR DESCRIPTION
alacritty 0.14.0 (22a44757) : 
"[WARN] Config warning: import has been deprecated; use general.import instead"