### PR TITLE
fix[readme]: import instructions key

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@
 2. Import the desired flavour config in your `alacritty.toml`:
 
     ```toml
-    general.import = [
+    [general]
+    import = [
       # uncomment the flavour you want below:
       "~/.config/alacritty/catppuccin-latte.toml"
       # "~/.config/alacritty/catppuccin-frappe.toml"


### PR DESCRIPTION
Using `general.import` and/or just `import` lead to `[WARN ] [alacritty_config_derive] Unused config key: ` errors.  `[general]import` seems to be properly recognized and themes imported.